### PR TITLE
Update Crispy Doom to 6.0

### DIFF
--- a/io.github.fabiangreffrath.Doom.json
+++ b/io.github.fabiangreffrath.Doom.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.fabiangreffrath.Doom",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "crispy-doom",
     "finish-args": [
@@ -28,8 +28,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/fabiangreffrath/crispy-doom.git",
-                    "tag": "crispy-doom-5.12.0",
-                    "commit": "4d416c7ffac8ef42f539652c29dc24e6b1012d13"
+                    "tag": "crispy-doom-6.0",
+                    "commit": "593f5b97023ed39b7640073160c06895bbfc3d26"
                 },
                 {
                     "type": "patch",

--- a/metainfo.patch
+++ b/metainfo.patch
@@ -18,7 +18,7 @@
    </description>
    <screenshots>
      <screenshot type="default">
-@@ -52,11 +63,13 @@
+@@ -52,11 +63,14 @@
      <content_attribute id="social-chat">intense</content_attribute>
    </content_rating>
    <releases>
@@ -28,6 +28,7 @@
 -    <release version="2.2.1" date="2016-04-09"/>
 -    <release version="2.2.0" date="2015-06-10"/>
 -    <release version="2.1.0" date="2014-10-22"/>
++    <release version="6.0" date="2023-03-31"/>
 +    <release version="5.12.0" date="2022-09-01"/>
 +    <release version="5.11.1" date="2022-02-10"/>
 +    <release version="5.10.3" date="2021-08-17"/>


### PR DESCRIPTION
This also updates the runtime to 22.08. However, this breaks the build due to SDL2_net not being found (which is strange as [the FreeDesktop runtime still has it](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/master/elements/components/sdl2-net.bst)).

- See https://github.com/fabiangreffrath/crispy-doom/issues/1061.
