### PR TITLE
Release 6.0

### DIFF
--- a/io.github.fabiangreffrath.Doom.json
+++ b/io.github.fabiangreffrath.Doom.json
@@ -62,7 +62,10 @@
                 "sed -i 's/Icon=crispy-heretic/Icon=io.github.fabiangreffrath.Doom.Heretic/' /app/share/applications/io.github.fabiangreffrath.Doom.Heretic.desktop",
                 "mv /app/share/icons/hicolor/128x128/apps/crispy-hexen.png /app/share/icons/hicolor/128x128/apps/io.github.fabiangreffrath.Doom.Hexen.png",
                 "mv /app/share/applications/io.github.fabiangreffrath.Hexen.desktop /app/share/applications/io.github.fabiangreffrath.Doom.Hexen.desktop",
-                "sed -i 's/Icon=crispy-hexen/Icon=io.github.fabiangreffrath.Doom.Hexen/' /app/share/applications/io.github.fabiangreffrath.Doom.Hexen.desktop"
+                "sed -i 's/Icon=crispy-hexen/Icon=io.github.fabiangreffrath.Doom.Hexen/' /app/share/applications/io.github.fabiangreffrath.Doom.Hexen.desktop",
+                "mv /app/share/icons/hicolor/128x128/apps/crispy-strife.png /app/share/icons/hicolor/128x128/apps/io.github.fabiangreffrath.Doom.Strife.png",
+                "mv /app/share/applications/io.github.fabiangreffrath.Strife.desktop /app/share/applications/io.github.fabiangreffrath.Doom.Strife.desktop",
+                "sed -i 's/Icon=crispy-strife/Icon=io.github.fabiangreffrath.Doom.Strife/' /app/share/applications/io.github.fabiangreffrath.Doom.Strife.desktop"
             ],
             "cleanup": [
                 "/share/applications/screensavers",

--- a/io.github.fabiangreffrath.Doom.json
+++ b/io.github.fabiangreffrath.Doom.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.fabiangreffrath.Doom",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "crispy-doom",
     "finish-args": [
@@ -15,6 +15,22 @@
     ],
     "rename-icon": "crispy-doom",
     "modules": [
+        {
+            "name": "SDL2_net",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/libsdl-org/SDL_net",
+                    "tag": "release-2.2.0",
+                    "commit": "669e75b84632e2c6cc5c65974ec9e28052cb7a4e"
+                }
+            ],
+            "cleanup": [
+                "/include",
+                "/lib"
+            ]
+        },
         {
             "name": "crispy-doom",
             "buildsystem": "autotools",

--- a/io.github.fabiangreffrath.Doom.json
+++ b/io.github.fabiangreffrath.Doom.json
@@ -39,6 +39,7 @@
             "post-install": [
                 "mv /app/share/icons/hicolor/128x128/apps/crispy-setup.png /app/share/icons/hicolor/128x128/apps/io.github.fabiangreffrath.Doom.Setup.png",
                 "mv /app/share/applications/io.github.fabiangreffrath.Setup.desktop /app/share/applications/io.github.fabiangreffrath.Doom.Setup.desktop",
+                "sed -i 's/Exec=crispy-setup/Exec=crispy-doom-setup/' /app/share/applications/io.github.fabiangreffrath.Doom.Setup.desktop",
                 "sed -i 's/Icon=crispy-setup/Icon=io.github.fabiangreffrath.Doom.Setup/' /app/share/applications/io.github.fabiangreffrath.Doom.Setup.desktop",
                 "mv /app/share/icons/hicolor/128x128/apps/crispy-heretic.png /app/share/icons/hicolor/128x128/apps/io.github.fabiangreffrath.Doom.Heretic.png",
                 "mv /app/share/applications/io.github.fabiangreffrath.Heretic.desktop /app/share/applications/io.github.fabiangreffrath.Doom.Heretic.desktop",

--- a/io.github.fabiangreffrath.Doom.json
+++ b/io.github.fabiangreffrath.Doom.json
@@ -44,8 +44,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/fabiangreffrath/crispy-doom.git",
-                    "tag": "crispy-doom-5.12.0",
-                    "commit": "4d416c7ffac8ef42f539652c29dc24e6b1012d13"
+                    "tag": "crispy-doom-6.0",
+                    "commit": "593f5b97023ed39b7640073160c06895bbfc3d26"
                 },
                 {
                     "type": "patch",

--- a/io.github.fabiangreffrath.Doom.json
+++ b/io.github.fabiangreffrath.Doom.json
@@ -69,7 +69,9 @@
             ],
             "cleanup": [
                 "/share/applications/screensavers",
-                "/share/metainfo/io.github.fabiangreffrath.Heretic.metainfo.xml"
+                "/share/metainfo/io.github.fabiangreffrath.Heretic.metainfo.xml",
+                "/share/metainfo/io.github.fabiangreffrath.Hexen.metainfo.xml",
+                "/share/metainfo/io.github.fabiangreffrath.Strife.metainfo.xml"
             ]
         }
     ]

--- a/metainfo.patch
+++ b/metainfo.patch
@@ -18,7 +18,7 @@
    </description>
    <screenshots>
      <screenshot type="default">
-@@ -52,11 +63,13 @@
+@@ -52,11 +63,14 @@
      <content_attribute id="social-chat">intense</content_attribute>
    </content_rating>
    <releases>
@@ -28,6 +28,7 @@
 -    <release version="2.2.1" date="2016-04-09"/>
 -    <release version="2.2.0" date="2015-06-10"/>
 -    <release version="2.1.0" date="2014-10-22"/>
++    <release version="6.0" date="2023-03-31"/>
 +    <release version="5.12.0" date="2022-09-01"/>
 +    <release version="5.11.1" date="2022-02-10"/>
 +    <release version="5.10.3" date="2021-08-17"/>


### PR DESCRIPTION
This PR does the following:
- Fix the Crispy Setup launcher
- Update the Freedesktop platform version to 22.08 and include a workaround for the broken SDL2_net support
- Update Crispy to the 6.0 version
- Add new support for Strife in 6.0