### PR TITLE
Update runtime and harden permissions

### DIFF
--- a/io.github.fabiangreffrath.Doom.json
+++ b/io.github.fabiangreffrath.Doom.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.fabiangreffrath.Doom",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "22.08",
+    "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "crispy-doom",
     "finish-args": [
@@ -10,27 +10,10 @@
         "--socket=fallback-x11",
         "--share=ipc",
         "--share=network",
-        "--socket=pulseaudio",
-        "--filesystem=home:ro"
+        "--socket=pulseaudio"
     ],
     "rename-icon": "crispy-doom",
     "modules": [
-        {
-            "name": "SDL2_net",
-            "buildsystem": "autotools",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/libsdl-org/SDL_net",
-                    "tag": "release-2.2.0",
-                    "commit": "669e75b84632e2c6cc5c65974ec9e28052cb7a4e"
-                }
-            ],
-            "cleanup": [
-                "/include",
-                "/lib"
-            ]
-        },
         {
             "name": "crispy-doom",
             "buildsystem": "autotools",


### PR DESCRIPTION
In recent [freedesktop](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases/freedesktop-sdk-23.08.11) SDL2_net was finally updated and fixed the issue. Also I have removed home access since one should move WAD to flatpak location.